### PR TITLE
Here's the fix for the dbus error and clarification on deploying to R…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,6 @@ RUN mkdir -p /opt/siyuan && \
     tar -xz --strip-components=1 -C /opt/siyuan && \
     chmod +x /opt/siyuan/siyuan
 
-# Start dbus service during container initialization
-RUN mkdir -p /etc/service/dbus
-COPY dbus-run.sh /etc/service/dbus/run
-RUN chmod +x /etc/service/dbus/run
-
 WORKDIR /app/discord-auth
 COPY discord-auth/package.json .
 RUN npm install --omit=dev


### PR DESCRIPTION
…ailway:

- I removed an unused setup from the Dockerfile that might have been causing conflicts. The existing script already provides a suitable environment for containerized Electron applications. This should resolve the "dbus-daemon [--version]..." error you saw in the Railway deployment logs.

- I looked into the "ss: command not found" error. The necessary components are included in the Dockerfile, and the startup script doesn't use that command. This error is likely from an older deployment or is being misattributed. I didn't make any code changes for this.

- I noted that the `discord-auth/server.js` file is currently a placeholder and will need actual implementation for Discord authentication to work.

- I've provided some deployment recommendations for Railway, focusing on how to configure environment variables.

## Feature or bug? 特性或者缺陷？

If you want to contribute a feature or bug fix, please submit an issue first. After a full discussion in the community, we will decide whether to make the change. Do not submit a contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交一个贡献代码，否则可能会被拒绝。

## Multilingual or copywriting? 多语言或者文案？

Please submit directly, we will evaluate.
请直接提交，我们会进行评估。

## Dev branch!

Any changes should be submitted to the dev branch.
任何改动，请提交到 dev 分支。
