### PR TITLE
Fix: Use dbus-launch to provide D-Bus session for Siyuan

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -7,22 +7,6 @@ set -euo pipefail
 : "${SIYUAN_FLAGS:=--no-sandbox --disable-gpu --disable-software-rasterizer --disable-dev-shm-usage}"
 export TZ="${TZ:-Asia/Singapore}"
 
-# Force create DBus directories and socket with proper permissions
-echo "Creating DBus directories and socket files..."
-mkdir -p /run/dbus
-mkdir -p /var/run/dbus
-touch /run/dbus/system_bus_socket
-chmod 755 /run/dbus
-chmod 755 /var/run/dbus
-chmod 777 /run/dbus/system_bus_socket
-
-# Set environment variables to minimize DBus errors
-export NO_AT_BRIDGE=1
-export DBUS_SESSION_BUS_ADDRESS="unix:path=/tmp/dbus-dummy.socket"
-export DBUS_SYSTEM_BUS_ADDRESS="unix:path=/tmp/dbus-dummy.socket"
-touch /tmp/dbus-dummy.socket
-chmod 777 /tmp/dbus-dummy.socket
-
 wait_for_port() {
   local host=$1 port=$2 timeout=$3
   for ((i=0;i<timeout;i++)); do
@@ -55,6 +39,7 @@ if [ -z "${KPID:-}" ]; then
   SIYUAN_FLAGS="${SIYUAN_FLAGS} --disable-features=DBus,BlinkGenPropertyTrees,UseChromeOSDirectVideoDecoder"
   
   echo "Starting SiYuan with flags: ${SIYUAN_FLAGS}"
+  eval $(dbus-launch --sh-syntax --exit-with-session)
   /opt/siyuan/siyuan --workspace=/siyuan/workspace --accessAuthCode="${SIYUAN_ACCESS_AUTH_CODE}" --port="${SIYUAN_INTERNAL_PORT}" ${SIYUAN_FLAGS} &
   KPID=$!
   if ! wait_for_port 127.0.0.1 "${SIYUAN_INTERNAL_PORT}" 30; then


### PR DESCRIPTION
Replaces the previous manual/dummy DBus socket setup in start.sh with dbus-launch. The Siyuan application was actively trying to connect to the DBus socket, leading to "Connection refused" errors with the dummy socket approach.

Changes in start.sh:
- Removed manual creation of /run/dbus directories and /tmp/dbus-dummy.socket.
- Removed manual setting of DBUS_SESSION_BUS_ADDRESS.
- The main /opt/siyuan/siyuan application is now launched with `eval $(dbus-launch --sh-syntax --exit-with-session)` to ensure it runs within a properly configured D-Bus session.

This approach should resolve the DBus connection errors by providing a functional, session-specific message bus for the application, as is common for containerized Electron apps.

## Feature or bug? 特性或者缺陷？

If you want to contribute a feature or bug fix, please submit an issue first. After a full discussion in the community, we will decide whether to make the change. Do not submit a contribution code directly, otherwise it may be rejected.
如果你想贡献一个特性或者缺陷修复，请先提交一个 issue。在社区充分讨论后，我们会决定是否进行变更。不要直接提交一个贡献代码，否则可能会被拒绝。

## Multilingual or copywriting? 多语言或者文案？

Please submit directly, we will evaluate.
请直接提交，我们会进行评估。

## Dev branch!

Any changes should be submitted to the dev branch.
任何改动，请提交到 dev 分支。
